### PR TITLE
bufix: send xml before http.Server closes the socket

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -270,7 +270,7 @@ Server.prototype.close = function close () {
  * Proxy the event listener requests to the created Net server
  */
 
-Object.keys(process.EventEmitter.prototype).forEach(function proxy (key){
+Object.keys(require('events').prototype).forEach(function proxy (key){
   Server.prototype[key] = Server.prototype[key] || function () {
     if (this.socket) {
       this.socket[key].apply(this.socket, arguments);

--- a/lib/server.js
+++ b/lib/server.js
@@ -123,7 +123,19 @@ Server.prototype.listen = function listen (port, server, cb){
     };
 
     // attach it
-    this.server.on('connection', this.server['@']);
+    // Note: in some versions of node.js (tested with v0.12.7) the http.Server
+    // class closes the socket immediately when it sees that the request is not
+    // HTTP, before we manage to send the xml! So we need to make sure that our
+    // connection listener is executed _first_. To do so we remove them all and
+    // we re-add them.
+    //
+    var listeners = this.server.listeners('connection');
+    listeners.unshift(this.server['@']);
+
+    this.server.removeAllListeners('connection');
+    listeners.forEach(function(l) {
+      me.server.on('connection', l);
+    });
   }
 
   // We add a callback method, so we can set a flag for when the server is `enabled` or `online`.

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,7 +66,8 @@ function Server (options, origins) {
       // Remove the inline policy listener if we close down
       // but only when the server was `online` (see listen prototype)
       if (me.server['@'] && me.server.online) {
-        me.server.removeListener('connection', me.server['@']);
+        var event = this.server.cert ? 'secureConnection' : 'connection';
+        me.server.removeListener(event, me.server['@']);
       }
 
       // not online anymore
@@ -129,12 +130,15 @@ Server.prototype.listen = function listen (port, server, cb){
     // connection listener is executed _first_. To do so we remove them all and
     // we re-add them.
     //
-    var listeners = this.server.listeners('connection');
+    // support both https ('secureConnection' event) and http ('connection' event)
+    //
+    var event = this.server.cert ? 'secureConnection' : 'connection';
+    var listeners = this.server.listeners(event);
     listeners.unshift(this.server['@']);
 
-    this.server.removeAllListeners('connection');
+    this.server.removeAllListeners(event);
     listeners.forEach(function(l) {
-      me.server.on('connection', l);
+      me.server.on(event, l);
     });
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -107,7 +107,7 @@ Server.prototype.listen = function listen (port, server, cb){
     // no one in their right mind would ever create a `@` prototype, so Im just gonna store
     // my function on the server, so I can remove it later again once the server(s) closes
     this.server['@'] = function connection (socket) {
-      socket.once('data', function requestData (data) {
+      function requestData (data) {
         // if it's a Flash policy request, and we can write to the 
         if (
              data
@@ -120,26 +120,30 @@ Server.prototype.listen = function listen (port, server, cb){
           try { socket.end(me.buffer); }
           catch (e) {}
         }
+      }
+
+      // Note: in some versions of node.js (tested with v0.12.7) the http.Server
+      // class closes the socket immediately when it sees that the request is not
+      // HTTP, before we manage to send the xml! So we need to make sure that our
+      // data listener is executed _first_. To do so we remove them all and
+      // we re-add them.
+      // In node v0.12.7 this trick was done for the connection event, in v4.2.1
+      // this was broken for some reason, but doing it for the data event works.
+      //
+      var listeners = socket.listeners('data');
+      socket.removeAllListeners('data');
+      socket.once('data', requestData);
+
+      listeners.forEach(function(l) {
+        socket.on('data', l);
       });
     };
 
     // attach it
-    // Note: in some versions of node.js (tested with v0.12.7) the http.Server
-    // class closes the socket immediately when it sees that the request is not
-    // HTTP, before we manage to send the xml! So we need to make sure that our
-    // connection listener is executed _first_. To do so we remove them all and
-    // we re-add them.
-    //
     // support both https ('secureConnection' event) and http ('connection' event)
     //
     var event = this.server.cert ? 'secureConnection' : 'connection';
-    var listeners = this.server.listeners(event);
-    listeners.unshift(this.server['@']);
-
-    this.server.removeAllListeners(event);
-    listeners.forEach(function(l) {
-      me.server.on(event, l);
-    });
+    this.server.on(event, this.server['@']);
   }
 
   // We add a callback method, so we can set a flag for when the server is `enabled` or `online`.


### PR DESCRIPTION
In some versions of node.js (tested with v0.12.7) the http.Server class closes
the socket immediately when it sees that the request is not HTTP, before we
manage to send the xml! So we need to make sure that our connection listener is
executed _first_. To do so we remove them all and we re-add them.

The 'inline response http' fails on node v0.12.7, it passes after the fix.
